### PR TITLE
v3.6.1

### DIFF
--- a/app/actors/Account.php
+++ b/app/actors/Account.php
@@ -2,49 +2,12 @@
 namespace BitsTheater\actors;
 use BitsTheater\actors\Understudy\AuthBasicAccount as BaseActor;
 use BitsTheater\scenes\Account as MyScene; /* @var $v MyScene */
-use com\blackmoonit\Strings;
-
 {//namespace begin
 
 class Account extends BaseActor {
 	
-	/**
-	 * Convert the fingerprint and circumstance string arrays into something
-	 * meaningful for the Account actor parent.
-	 * @see \BitsTheater\actors\Understudy\AuthBasicAccount::registerViaMobile()
-	 */
-	public function registerViaMobile() {
-		//shortcut variable $v also in scope in our view php file.
-		$v =& $this->scene;
-		$v->fingerprints = $v->cnvFingerprints2KeyedArray($v->fingerprints);
-		$v->circumstances = $v->cnvCircumstances2KeyedArray($v->circumstances);
-		return parent::registerViaMobile();
-	}
-	
-	/**
-	 * Convert the fingerprint and circumstance string arrays into something
-	 * meaningful for the Account actor parent. Also, react to the ping/pong
-	 * request in our own fashion.
-	 * @see \BitsTheater\actors\Understudy\AuthBasicAccount::requestMobileAuth()
-	 */
-	public function requestMobileAuth($aPing=null) {
-		//shortcut variable $v also in scope in our view php file.
-		$v =& $this->scene;
-		$v->fingerprints = $v->cnvFingerprints2KeyedArray($v->fingerprints);
-		$v->circumstances = $v->cnvCircumstances2KeyedArray($v->circumstances);
-		//$this->debugLog(__METHOD__.' v='.$this->debugStr($v));
-		
-		parent::requestMobileAuth($aPing);
-		
-		if (empty($v->results) && $aPing===VIRTUAL_HOST_NAME) {
-			$v->results = array(
-					'user_token' => 'ping',
-					'auth_token' => 'pong',
-					'api_version_seq' => $v->getRes('website/api_version_seq'),
-			);
-		}
-	}
-	
+	//nothing to override or do here, yet
+
 }//end class
 
 }//end namespace

--- a/app/costumes/APIResponse.php
+++ b/app/costumes/APIResponse.php
@@ -54,12 +54,18 @@ class APIResponse extends BaseCostume {
 	 * If an exception is caught, set the API response as a failure
 	 * and return the error information.
 	 * @param \BitsTheater\BrokenLeg $aError
+	 * @param boolean $bSetResponseCode specifies whether to overwrite the
+	 *  response code of the ongoing HTTP transaction with the error code of the
+	 *  `BrokenLeg` instance. Defaults to true, but you might want to set as
+	 *  false if you're using an `APIResponse` object as an interim data
+	 *  structure for some more elaborate transaction.
 	 */
-	public function setError( BrokenLeg $aError )
+	public function setError( BrokenLeg $aError, $bSetResponseCode=true )
 	{
 		$this->status = self::STATUS_FAILURE ;
 		$this->error = $aError->toResponseObject() ;
-		http_response_code( $aError->getCode() ) ;
+		if( $bSetResponseCode )
+			http_response_code( $aError->getCode() ) ;
 	}
 	
 	/**

--- a/app/costumes/WornForHttpAuthBasic.php
+++ b/app/costumes/WornForHttpAuthBasic.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Copyright (C) 2016 Blackmoon Info Tech Services
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace BitsTheater\costumes ;
+{ // begin namespace
+
+/**
+ * A set of methods useful for decoding the Basic scheme of a HTTP Auth header.
+ * @since BitsTheater 3.6.1
+ */
+trait WornForHttpAuthBasic
+{
+	/**
+	 * Basic HTTP Auth name of the account.
+	 * @var string
+	 */
+	protected $account_name;
+	/**
+	 * Basic HTTP Auth password for the account.
+	 * @var string
+	 */
+	protected $pw_input;
+
+	protected function parseAuthHeaderAsAuthBasic($aAuthData) {
+		list($this->account_name, $this->pw_input) = explode(':', $aAuthData);
+	}
+	
+	/**
+	 * @return string Return the account name specified in the header.
+	 */
+	public function getHttpAuthBasicAccountName() {
+		return $this->account_name;
+	}
+
+	/**
+	 * @return string Return the password specified in the header.
+	 */
+	public function getHttpAuthBasicAccountPw() {
+		return $this->pw_input;
+	}
+	
+} // end trait
+
+} // end namespace

--- a/app/costumes/WornForHttpAuthBroadway.php
+++ b/app/costumes/WornForHttpAuthBroadway.php
@@ -1,0 +1,143 @@
+<?php
+/*
+ * Copyright (C) 2016 Blackmoon Info Tech Services
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace BitsTheater\costumes ;
+use com\blackmoonit\Arrays;
+use com\blackmoonit\Strings;
+{ // begin namespace
+
+/**
+ * Useful traits for decoding the Broadway scheme of a HTTP Auth header.
+ * @since BitsTheater 3.6.1
+ */
+trait WornForHttpAuthBroadway
+{
+	/**
+	 * Broadway http auth user auth_id.
+	 * @var string
+	 */
+	public $auth_id = null;
+	/**
+	 * Broadway HTTP Auth token.
+	 * @var string
+	 */
+	public $auth_token = null;
+	/**
+	 * Broadway http auth device's fingerprints which are
+	 * non-volatile between API calls.
+	 * @var string
+	 */
+	public $fingerprints = null;
+	/**
+	 * Fingerprints may be defined with a unique separator.
+	 * Defaults to ", ".
+	 * @var string
+	 */
+	public $fsep = ', ';
+	/**
+	 * Fingerprint param for a mobile/OS instance ID.
+	 * @var string
+	 */
+	public $mobile_id;
+	/**
+	 * Fingerprint param for the hardware ID.
+	 * @var string
+	 */
+	public $device_id;
+	/**
+	 * Broadway HTTP Auth device's circumstances which may be
+	 * volatile between API calls. Contains items like GPS
+	 * location and current timestamp.
+	 * @var string[]
+	 */
+	public $circumstances = null;
+	/**
+	 * Circumstances may be defined with a unique separator.
+	 * Defaults to ", ".
+	 * @var string
+	 */
+	public $csep = ', ';
+	/**
+	 * Circumstance param for timestamp of circumstance data.
+	 * @var string
+	 */
+	public $circumstance_ts;
+	/**
+	 * Circumstance param for the GPS latitude.
+	 * Stored here as a decimal string rather than a double.
+	 * @var string
+	 */
+	public $device_latitude;
+	/**
+	 * Circumstance param for the GPS longitude.
+	 * Stored here as a decimal string rather than a double.
+	 * @var string
+	 */
+	public $device_longitude;
+	/**
+	 * Circumstance param for the device name.
+	 * @var string
+	 */
+	public $device_name;
+	/**
+	 * Is the GPS service disabled?
+	 * @var boolean
+	 */
+	public $device_gps_disabled = false;
+
+	/**
+	 * Parse the Auth Data out into various properties.
+	 * @param string $aAuthData
+	 */
+	protected function parseAuthHeaderAsAuthBroadway($aAuthData) {
+		$theParamsList = Arrays::parseCsvParamsStringToArray($aAuthData);
+		if (!empty($theParamsList)) {
+			foreach ($theParamsList as $theParams)
+				$this->setDataFrom($theParams);
+		}
+		$dbAuth = $this->getProp('Auth');
+		$this->setDataFrom($dbAuth->parseAuthBroadwayFingerprints(
+				explode($this->fsep, Strings::stripEnclosure($this->fingerprints,'[',']'))
+		));
+		$this->setDataFrom($dbAuth->parseAuthBroadwayCircumstances(
+				explode($this->csep, Strings::stripEnclosure($this->circumstances,'[',']'))
+		));
+	}
+	
+	public function getDeviceName() {
+		return $this->device_name;
+	}
+	
+	public function getLatLong() {
+		return array($this->device_latitude, $this->device_longitude);
+	}
+	
+	public function getLatitude() {
+		return $this->device_latitude;
+	}
+	
+	public function getLongitude() {
+		return $this->device_longitude;
+	}
+	
+	public function getTimestamp() {
+		return $this->circumstance_ts;
+	}
+	
+} // end trait
+
+} // end namespace

--- a/app/costumes/WornForHttpAuthBroadway.php
+++ b/app/costumes/WornForHttpAuthBroadway.php
@@ -104,18 +104,21 @@ trait WornForHttpAuthBroadway
 	 * @param string $aAuthData
 	 */
 	protected function parseAuthHeaderAsAuthBroadway($aAuthData) {
-		$theParamsList = Arrays::parseCsvParamsStringToArray($aAuthData);
+		if (!empty($aAuthData))
+			$theParamsList = Arrays::parseCsvParamsStringToArray($aAuthData);
 		if (!empty($theParamsList)) {
 			foreach ($theParamsList as $theParams)
 				$this->setDataFrom($theParams);
 		}
 		$dbAuth = $this->getProp('Auth');
-		$this->setDataFrom($dbAuth->parseAuthBroadwayFingerprints(
-				explode($this->fsep, Strings::stripEnclosure($this->fingerprints,'[',']'))
-		));
-		$this->setDataFrom($dbAuth->parseAuthBroadwayCircumstances(
-				explode($this->csep, Strings::stripEnclosure($this->circumstances,'[',']'))
-		));
+		if (!empty($this->fingerprints))
+			$this->setDataFrom($dbAuth->parseAuthBroadwayFingerprints(
+					explode($this->fsep, Strings::stripEnclosure($this->fingerprints,'[',']'))
+			));
+		if (!empty($this->circumstances))
+			$this->setDataFrom($dbAuth->parseAuthBroadwayCircumstances(
+					explode($this->csep, Strings::stripEnclosure($this->circumstances,'[',']'))
+			));
 	}
 	
 	public function getDeviceName() {

--- a/app/models/Accounts.php
+++ b/app/models/Accounts.php
@@ -4,9 +4,14 @@ namespace BitsTheater\models;
 use BitsTheater\models\PropCloset\BitsAccounts as BaseModel;
 {//begin namespace
 
-class Accounts extends BaseModel {
-
-	//nothing to extend, yet
+class Accounts extends BaseModel
+{
+	/**
+	 * The name of the model which can be used in IDirected::getProp().
+	 * @var string
+	 * @since BitsTheater 3.6.1
+	 */
+	const MODEL_NAME = __CLASS__ ;
 	
 }//end class
 

--- a/app/models/Auth.php
+++ b/app/models/Auth.php
@@ -4,10 +4,16 @@ namespace BitsTheater\models;
 use BitsTheater\models\PropCloset\AuthBasic as BaseModel;
 {//namespace begin
 
-class Auth extends BaseModel {
+class Auth extends BaseModel
+{
+	/**
+	 * The name of the model which can be used in IDirected::getProp().
+	 * @var string
+	 * @since BitsTheater 3.6.1
+	 */
+	const MODEL_NAME = __CLASS__ ;
 	
-	//nothing to extend, yet
-	
+
 }//end class
 
 }//end namespace

--- a/app/models/AuthGroups.php
+++ b/app/models/AuthGroups.php
@@ -4,9 +4,14 @@ namespace BitsTheater\models;
 use BitsTheater\models\PropCloset\BitsGroups as BaseModel;
 {//begin namespace
 
-class AuthGroups extends BaseModel {
-
-	//nothing to extend, yet
+class AuthGroups extends BaseModel
+{
+	/**
+	 * The name of the model which can be used in IDirected::getProp().
+	 * @var string
+	 * @since BitsTheater 3.6.1
+	 */
+	const MODEL_NAME = __CLASS__ ;
 	
 }//end class
 

--- a/app/models/Config.php
+++ b/app/models/Config.php
@@ -4,9 +4,14 @@ namespace BitsTheater\models;
 use BitsTheater\models\PropCloset\BitsConfig as BaseModel;
 {//begin namespace
 
-class Config extends BaseModel {
-
-	//nothing to extend, yet
+class Config extends BaseModel
+{
+	/**
+	 * The name of the model which can be used in IDirected::getProp().
+	 * @var string
+	 * @since BitsTheater 3.6.1
+	 */
+	const MODEL_NAME = __CLASS__ ;
 	
 }//end class
 

--- a/app/models/Permissions.php
+++ b/app/models/Permissions.php
@@ -4,8 +4,15 @@ namespace BitsTheater\models;
 use BitsTheater\models\PropCloset\AuthPermissions as BaseModel;
 {//namespace begin
 
-class Permissions extends BaseModel {
-
+class Permissions extends BaseModel
+{
+	/**
+	 * The name of the model which can be used in IDirected::getProp().
+	 * @var string
+	 * @since BitsTheater 3.6.1
+	 */
+	const MODEL_NAME = __CLASS__ ;
+	
 }//end class
 
 }//end namespace

--- a/app/models/PropCloset/AuthBasic.php
+++ b/app/models/PropCloset/AuthBasic.php
@@ -109,6 +109,13 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 	 * @var string
 	 */
 	const TOKEN_PREFIX_ANTI_CSRF = 'aC';
+	/**
+	 * A mobile hardware ID to account mapping token prefix.
+	 * @var string
+	 * @since BitsTheater 3.6.1
+	 */
+	const TOKEN_PREFIX_HARDWARE_ID_TO_ACCOUNT = 'hwid2acct';
+	
 	
 	public function setupAfterDbConnected() {
 		parent::setupAfterDbConnected();
@@ -1086,12 +1093,19 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 			return $this->checkWebFormForTicket($dbAccounts, $aScene);
 		}
 		//check for HttpAuth header
-		$theAuthHeader = new HttpAuthHeader($aScene->HTTP_AUTHORIZATION);
+		$theAuthHeader = HttpAuthHeader::fromHttpAuthHeader(
+				$this->getDirector(), $aScene->HTTP_AUTHORIZATION
+		);
 		switch ($theAuthHeader->auth_scheme) {
 			case 'Basic':
-				$aScene->{self::KEY_userinfo} = $theAuthHeader->username;
-				$aScene->{self::KEY_pwinput} = $theAuthHeader->pw_input;
-				unset($this->HTTP_AUTHORIZATION); //keeping lightly protected pw in memory can be bad.
+				$aScene->{self::KEY_userinfo} = $theAuthHeader->getHttpAuthBasicAccountName();
+				$aScene->{self::KEY_pwinput} = $theAuthHeader->getHttpAuthBasicAccountPw();
+				//keeping lightly protected pw in memory can be bad, clear out usage asap.
+				$theAuthHeader = null;
+				if (!empty($this->HTTP_AUTHORIZATION))
+					unset($this->HTTP_AUTHORIZATION);
+				else
+					unset($_SERVER['HTTP_AUTHORIZATION']);
 				return $this->checkWebFormForTicket($dbAccounts, $aScene);
 			case 'Broadway':
 				//$this->debugLog(__METHOD__.' chkhdr='.$this->debugStr($theAuthHeader));
@@ -1101,10 +1115,10 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 					//$this->debugLog(__METHOD__.' arow='.$this->debugStr($theAuthTokenRow));
 					if (!empty($theAuthTokenRow)) {
 						$theAuthMobileRows = $this->getAuthMobilesByAuthId($theAuthHeader->auth_id);
+						//$this->debugLog(__METHOD__.' fp='.$theAuthHeader->fingerprints);
 						foreach ($theAuthMobileRows as $theMobileRow) {
-							$theFingerprintStr = $theAuthHeader->fingerprints;
-							//$this->debugLog(__METHOD__.' fstr1='.$theFingerprintStr);
-							if (Strings::hasher($theFingerprintStr, $theMobileRow['fingerprint_hash'])) {
+							//$this->debugLog(__METHOD__.' chk against mobile_id='.$theMobileRow['mobile_id']);
+							if (Strings::hasher($theAuthHeader->fingerprints, $theMobileRow['fingerprint_hash'])) {
 								//$this->debugLog(__METHOD__.' fmatch?=true');
 								$theUserAccount = $this->getAccountInfoCache($dbAccounts, $theAuthTokenRow['account_id']);
 								if (!empty($theUserAccount) &&
@@ -1121,6 +1135,7 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 									return true;
 								}
 							}
+							//else $this->debugLog(__METHOD__.' no match against '.$theMobileRow['fingerprint_hash']);
 						}
 					}//if auth token row !empty
 				}
@@ -1532,29 +1547,18 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 	}
 
 	/**
-	 * Standard mechanism to convert the fingerprint array to a string so it can be
-	 * hashed or matched against a prior hash. This should match how the mobile app
-	 * will be creating the string inside the http auth header.
-	 * @param string[] $aFingerprints - the fingerprint array
-	 * @return string Returns the array converted to a string.
-	 */
-	protected function cnvFingerprintArrayToString($aFingerprints) {
-		return '['.implode(', ', $aFingerprints).']';
-	}
-
-	/**
 	 * Store device data so that we can determine if user/pw are required again.
 	 * @param array $aAuthRow - an array containing the auth row data.
-	 * @param $aFingerprints - the device's information to store
-	 * @param $aCircumstances - mobile device circumstances (gps, timestamp, etc.)
+	 * @param $aHttpAuthHeader - the HTTP auth header object
 	 * @return array Returns the field data saved.
 	 */
-	public function registerMobileFingerprints($aAuthRow, $aFingerprints, $aCircumstances) {
-		if (!empty($aAuthRow) && !empty($aFingerprints)) {
-			unset($aCircumstances->created_ts); //do not want outside influence on created_ts value.
-			unset($aCircumstances->updated_ts); //do not want outside influence on updated_ts value.
-			unset($aCircumstances->mobile_id); //do not want outside influence on mobile_id value.
-			$theSql = SqlBuilder::withModel($this)->obtainParamsFrom($aCircumstances);
+	public function registerMobileFingerprints($aAuthRow, HttpAuthHeader $aHttpAuthHeader) {
+		if (!empty($aAuthRow) && !empty($aHttpAuthHeader)) {
+			$theSql = SqlBuilder::withModel($this)->obtainParamsFrom(array(
+					'device_name' => $aHttpAuthHeader->getDeviceName(),
+					'latitude' => $aHttpAuthHeader->getLatitude(),
+					'longitude' => $aHttpAuthHeader->getLongitude(),
+			));
 			$theSql->startWith('INSERT INTO')->add($this->tnAuthMobile);
 			$this->setAuditFieldsOnInsert($theSql);
 			$theSql->mustAddParam('mobile_id', Strings::createUUID());
@@ -1568,19 +1572,8 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 
 			//do not store the fingerprints as if db is compromised, this might be
 			//  considered "sensitive". just keep a hash instead, like a password.
-			//$this->debugLog(__METHOD__.' aid='.$aAuthRow['account_id'].' fp='.$this->debugStr($aFingerprints));
-			/*
-			$theSql->addParam('device_id');
-			$theSql->addParam('app_version_name');
-			$theSql->addParam('device_memory');
-			$theSql->addParam('locale');
-			$theSql->addParam('app_fingerprint');
-			*/
-			//mimics Java's Arrays.toString(arr) so we do not have to parse the auth header value
-			$theFingerprintStr = $this->cnvFingerprintArrayToString($aFingerprints);
-			$theFingerprintHash = Strings::hasher($theFingerprintStr);
+			$theFingerprintHash = Strings::hasher($aHttpAuthHeader->fingerprints);
 			$theSql->mustAddParam('fingerprint_hash', $theFingerprintHash);
-			//$theSql->mustAddParam('fingerprint_str', $theFingerprintStr);
 
 			$theSql->execDML();
 
@@ -1596,39 +1589,42 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 	 * a new auth token and return it as well as place it as a cookie with duration of 1 day.
 	 * @param number $aAcctId - the account id.
 	 * @param string $aAuthId - the auth id.
+	 * @param $aHttpAuthHeader - the HTTP auth header object
 	 * @return string Returns the auth token generated.
 	 */
-	protected function generateAuthTokenForMobile($aAcctId, $aAuthId) {
-		//generate a token with "mA" so we can tell them apart from cookie tokens
-		$theUserToken = $this->director->app_id.'-'.$aAuthId;
-		$theAuthToken = $this->generateAuthToken($aAuthId, $aAcctId, self::TOKEN_PREFIX_MOBILE);
-		/* do not give mobile the auth token in a cookie!
-		$theStaleTime = time()+($this->getCookieDurationInDays('duration_1_day')*(60*60*24));
-		$this->setMySiteCookie(self::KEY_userinfo, $theUserToken, $theStaleTime);
-		$this->setMySiteCookie(self::KEY_token, $theAuthToken, $theStaleTime);
-		*/
+	protected function generateAuthTokenForMobile($aAcctId, $aAuthId, HttpAuthHeader $aHttpAuthHeader) {
+		//ensure we've cleaned house recently
+		$this->removeStaleMobileAuthTokens();
+		//see if we've already got a token for this device
+		$theTokenPrefix = self::TOKEN_PREFIX_MOBILE;
+		if (!empty($aHttpAuthHeader) && !empty($aHttpAuthHeader->mobile_id))
+			$theTokenPrefix .= $aHttpAuthHeader->mobile_id;
+		$theTokenList = $this->getAuthTokens($aAuthId, $aAcctId, $theTokenPrefix . '%', true);
+		//if we have a token, return it, else create a new one
+		if (!empty($theTokenList))
+			$theAuthToken = $theTokenList[0]['token'];
+		else
+			$theAuthToken = $this->generateAuthToken($aAuthId, $aAcctId, $theTokenPrefix);
 		return $theAuthToken;
 	}
 
 	/**
 	 * Someone entered a user/pw combo correctly from a mobile device, give them tokens!
 	 * @param AccountInfoCache $aAcctInfo - successfully logged in account info.
-	 * @param $aFingerprints - mobile device info
-	 * @param $aCircumstances - mobile device circumstances (gps, timestamp, etc.)
+	 * @param $aHttpAuthHeader - the HTTP auth header object
 	 * @return array|NULL Returns the tokens needed for ez-auth later.
 	 */
-	public function requestMobileAuthAfterPwLogin(AccountInfoCache $aAcctInfo, $aFingerprints, $aCircumstances) {
+	public function requestMobileAuthAfterPwLogin(AccountInfoCache $aAcctInfo, HttpAuthHeader $aHttpAuthHeader) {
 		$theResults = null;
 		$theAuthRow = $this->getAuthByAccountId($aAcctInfo->account_id);
-		if (!empty($theAuthRow) && !empty($aFingerprints)) {
+		if (!empty($theAuthRow) && !empty($aHttpAuthHeader)) {
 			$theMobileRow = null;
 			//see if they have a mobile auth row already
 			$theAuthMobileRows = $this->getAuthMobilesByAccountId($aAcctInfo->account_id);
 			if (!empty($theAuthMobileRows)) {
-				$theFingerprintStr = $this->cnvFingerprintArrayToString($aFingerprints);
 				//see if fingerprints match any of the existing records and return that user_token if so
 				foreach ($theAuthMobileRows as $theAuthMobileRow) {
-					if (Strings::hasher($theFingerprintStr, $theAuthMobileRow['fingerprint_hash'])) {
+					if (Strings::hasher($aHttpAuthHeader->fingerprints, $theAuthMobileRow['fingerprint_hash'])) {
 						$theMobileRow = $theAuthMobileRow;
 						break;
 					}
@@ -1637,11 +1633,12 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 			//$this->debugLog('mobile_pwlogin'.' mar='.$this->debugStr($theAuthMobileRow));
 			if (empty($theMobileRow)) {
 				//first time they logged in via this mobile device, record it
-				$theMobileRow = $this->registerMobileFingerprints($theAuthRow, $aFingerprints, $aCircumstances);
+				$theMobileRow = $this->registerMobileFingerprints($theAuthRow, $aHttpAuthHeader);
 			}
 			if (!empty($theMobileRow)) {
-				$this->removeStaleMobileAuthTokens();
-				$theAuthToken = $this->generateAuthTokenForMobile($aAcctInfo->account_id, $theAuthRow['auth_id']);
+				$theAuthToken = $this->generateAuthTokenForMobile($aAcctInfo->account_id,
+						$theAuthRow['auth_id'], $aHttpAuthHeader
+				);
 				$theResults = array(
 						'account_name' => $aAcctInfo->account_name,
 						'auth_id' => $theAuthRow['auth_id'],
@@ -1661,39 +1658,43 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 	 * and generate the proper token cookies.
 	 * @param string $aAuthId - the account's auth_id
 	 * @param string $aUserToken - the user token previously given by this website
-	 * @param $aFingerprints - mobile device info
-	 * @param $aCircumstances - mobile device circumstances (gps, timestamp, etc.)
+	 * @param $aHttpAuthHeader - the HTTP auth header object
 	 * @return array|NULL Returns the tokens needed for ez-auth later.
 	 */
-	public function requestMobileAuthAutomatedByTokens($aAuthId, $aUserToken, $aFingerprints, $aCircumstances) {
+	public function requestMobileAuthAutomatedByTokens($aAuthId, $aUserToken, HttpAuthHeader $aHttpAuthHeader) {
 		$theResults = null;
 		$dbAccounts = $this->getProp('Accounts');
 		$theAuthRow = $this->getAuthByAuthId($aAuthId);
 		$theAcctRow = (!empty($theAuthRow)) ? $dbAccounts->getAccount($theAuthRow['account_id']) : null;
-		if (!empty($theAcctRow) && !empty($theAuthRow) && !empty($aFingerprints)) {
-			//$this->debugLog(__METHOD__.' c='.$this->debugStr($aCircumstances));
+		if (!empty($theAcctRow) && !empty($theAuthRow) && !empty($aHttpAuthHeader)) {
+			//$this->debugLog(__METHOD__.' AH='.$this->debugStr($aHttpAuthHeader));
 			//they must have a mobile auth row already
-			$theAuthMobileRows = $this->getAuthMobilesByAccountId($theAcctRow['account_id']);
+			$theSql = SqlBuilder::withModel($this)->obtainParamsFrom(array(
+					'account_id' => $theAcctRow['account_id'],
+					'account_token' => $aUserToken,
+			));
+			$theSql->startWith('SELECT * FROM')->add($this->tnAuthMobile);
+			$theSql->startWhereClause()->mustAddParam('account_id');
+			$theSql->setParamPrefix(' AND ')->mustAddParam('account_token');
+			$theSql->endWhereClause();
+			$theAuthMobileRows = $theSql->query();
 			if (!empty($theAuthMobileRows)) {
-				$theFingerprintStr = $this->cnvFingerprintArrayToString($aFingerprints);
 				//see if fingerprints match any of the existing records and return that user_token if so
 				foreach ($theAuthMobileRows as $theAuthMobileRow) {
-					if (Strings::hasher($theFingerprintStr, $theAuthMobileRow['fingerprint_hash'])) {
-						$theUserToken = $theAuthMobileRow['account_token'];
+					if (Strings::hasher($aHttpAuthHeader->fingerprints, $theAuthMobileRow['fingerprint_hash'])) {
+						//$this->debugLog(__METHOD__.' \o/');
+						$theAuthToken = $this->generateAuthTokenForMobile($theAcctRow['account_id'],
+								$theAuthRow['auth_id'], $aHttpAuthHeader
+						);
+						$theResults = array(
+								'account_name' => $theAcctRow['account_name'],
+								'user_token' => $aUserToken,
+								'auth_token' => $theAuthToken,
+								'api_version_seq' => $this->getRes('website/api_version_seq'),
+						);
+						//$this->debugLog(__METHOD__.' r='.$this->debugStr($theResults));
 						break;
 					}
-				}
-				//$this->debugLog(__METHOD__.' ut='.$theUserToken.' param='.$aUserToken);
-				//if the user_token we found equals the one passed in as param, then authentication SUCCESS
-				if (!empty($theUserToken) && $theUserToken===$aUserToken) {
-					//$this->debugLog(__METHOD__.' \o/');
-					$theAuthToken = $this->generateAuthTokenForMobile($theAcctRow['account_id'], $theAuthRow['auth_id']);
-					$theResults = array(
-							'account_name' => $theAcctRow['account_name'],
-							'user_token' => $theUserToken,
-							'auth_token' => $theAuthToken,
-							'api_version_seq' => $this->getRes('website/api_version_seq'),
-					);
 				}
 			}
 		}
@@ -1820,6 +1821,62 @@ class AuthBasic extends BaseModel implements IFeatureVersioning
 		}
 	}
 
+	/**
+	 * Create and store an TOKEN_PREFIX_HARDWARE_ID_TO_ACCOUNT token mapped
+	 * to an account. The token is guaranteed to be universally unique.
+	 * @param string $aAuthId - token mapped to auth record by this id.
+	 * @param number $aAcctId - the account which will map to this token.
+	 * @param string $aHardwareId - the hardware ID of the moblie device.
+	 * @return string Return the token generated.
+	 * @since BitsTheater 3.6.1
+	 */
+	public function generateAutoLoginForMobileDevice($aAuthId, $aAcctId, $aHardwareId) {
+		$theAuthToken = self::TOKEN_PREFIX_HARDWARE_ID_TO_ACCOUNT . ':'
+			. $aHardwareId . ':'
+			. Strings::createUUID()
+		;
+		$this->insertAuthToken($aAuthId, $aAcctId, $theAuthToken);
+		return $theAuthToken;
+	}
+
+	/**
+	 * API fingerprints from mobile device. Recommended that
+	 * your website mixes their order up, at the very least.
+	 * @param string[] $aFingerprints - string array of device info.
+	 * @return string[] Return a keyed array of device info.
+	 * @since BitsTheater 3.6.1
+	 */
+	public function parseAuthBroadwayFingerprints($aFingerprints) {
+		if (!empty($aFingerprints)) {
+			return array(
+					'app_signature' => $aFingerprints[0],
+					'mobile_id' => $aFingerprints[1],
+					'device_id' => $aFingerprints[2],
+					'device_locale' => $aFingerprints[3],
+					'device_memory' => (is_numeric($aFingerprints[4]) ? $aFingerprints[4] : null),
+			);
+		} else return array();
+	}
+	
+	/**
+	 * API circumstances from mobile device. Recommended that
+	 * your website mixes their order up, at the very least.
+	 * @param string[] $aCircumstances - string array of device meta,
+	 * such as current GPS, user device name setting, current timestamp, etc.
+	 * @return string[] Return a keyed array of device meta.
+	 * @since BitsTheater 3.6.1
+	 */
+	public function parseAuthBroadwayCircumstances($aCircumstances) {
+		if (!empty($aCircumstances)) {
+			return array(
+					'circumstance_ts' => $aCircumstances[0],
+					'device_name' => $aCircumstances[1],
+					'device_latitude' => (is_float($aCircumstances[2]) ? $aCircumstances[2] : null),
+					'device_longitude' => (is_float($aCircumstances[3]) ? $aCircumstances[3] : null),
+			);
+		} else return array();
+	}
+	
 }//end class
 
 }//end namespace

--- a/app/models/SetupDb.php
+++ b/app/models/SetupDb.php
@@ -7,8 +7,15 @@ use com\blackmoonit\exceptions\DbException;
 use PDOException;
 {//begin namespace
 
-class SetupDb extends BaseModel {
-
+class SetupDb extends BaseModel
+{
+	/**
+	 * The name of the model which can be used in IDirected::getProp().
+	 * @var string
+	 * @since BitsTheater 3.6.1
+	 */
+	const MODEL_NAME = __CLASS__ ;
+	
 	/**
 	 * During website development, some models may get orphaned. Prevent them
 	 * from being used by overriding and disallowing the old model names.

--- a/app/scenes/Account.php
+++ b/app/scenes/Account.php
@@ -65,42 +65,6 @@ class Account extends MyScene {
 		$theKey = $this->getUseCookieKey();
 		return $this->$theKey;
 	}
-	
-	/**
-	 * API fingerprints from mobile device. Recomended that
-	 * your website mixes their order up, at the very least.
-	 * @param string[] $aFingerprints - string array of device info.
-	 * @return string[] Return a keyed array of device info.
-	 */
-	public function cnvFingerprints2KeyedArray($aFingerprints) {
-		if (!empty($aFingerprints)) {
-			return array(
-					'device_id' => $aFingerprints[0],
-					'app_version' => $aFingerprints[1],
-					'device_memory' => (is_numeric($aFingerprints[2]) ? $aFingerprints[2] : null),
-					'locale' => $aFingerprints[3],
-					'app_signature' => $aFingerprints[4],
-			);
-		} else return array();
-	}
-
-	/**
-	 * API circumstances from mobile device. Recommended that
-	 * your website mixes their order up, at the very least.
-	 * @param string[] $aCircumstances - string array of device meta,
-	 * such as current GPS, user device name setting, current timestamp, etc.
-	 * @return string[] Return a keyed array of device meta.
-	 */
-	public function cnvCircumstances2KeyedArray($aCircumstances) {
-		if (!empty($aCircumstances)) {
-			return array(
-					'now_ts' => $aCircumstances[0],
-					'latitude' => (is_numeric($aCircumstances[1]) ? $aCircumstances[1] : null),
-					'longitude' => (is_numeric($aCircumstances[2]) ? $aCircumstances[2] : null),
-					'device_name' => $aCircumstances[3],
-			);
-		} else return array();
-	}
 
 }//end class
 

--- a/lib/com/blackmoonit/Arrays.php
+++ b/lib/com/blackmoonit/Arrays.php
@@ -283,6 +283,27 @@ class Arrays {
 		}
 	}
 
+	/**
+	 * Convert a CSV string of params into a true associative array.
+	 * e.g. '"param1"="value1","param2"="value2"\n"param3"="value3"' becomes
+	 *     [ [param1 => value1, param2 => value2], [param3 => value3] ]
+	 * @param string $aCsvString - the string to parse
+	 * @return array Returns an array of associative arrays of key => values.
+	 */
+	static public function parseCsvParamsStringToArray($aCsvString) {
+		$theResult = array();
+		//safely convert the string into array of key=value strings
+		$theParamsStrList = self::parse_csv_to_array($aCsvString);
+		if (!empty($theParamsStrList)) {
+			foreach ($theParamsStrList as $theParamsStr) {
+				//convert the key=value strs into a true associative array
+				$theResult[] = self::cnvKeyValuePairsToAssociativeArray($theParamsStr);
+			}
+		}
+		return $theResult;
+	}
+	
+	
 }//end class
 
 }//end namespace


### PR DESCRIPTION
  1. APIResponse::setError() added a boolean SetResponseCode parameter
  1. added Arrays::parseCsvParamsStringToArray() util method to convert a CSV string of params into a true associative 2D array.
  1. AuthBasic::removeStaleTokens() was broken since it compared a timestamp with a string, not a SQL error, but a logic error.
  1. introduced the MODEL_NAME constant inside app/models so that descendant websites may use IDirected->getProp( ModelClass::MODEL_NAME ) rather than a string which may get misspelled.
  1. refactored fingerprints/circumstances POST vars to parse `auth_header_data` as if constructed for the HTTP Authorization header so there is only one way to build/parse Broadway Auth data; easier to extend and fewer mistakes that way; modified ping/pong results; added ability to pre-provision hardware ID mapped to an auth account; added traits for HTTP Auth header to make it easier to understand.